### PR TITLE
fix: Upgraded dependencies for Node 16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,8 +21,8 @@
       "devDependencies": {
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-build": "9.1.1",
-        "@edx/frontend-platform": "1.14.9",
-        "@edx/paragon": "^16.0.0",
+        "@edx/frontend-platform": "1.15.1",
+        "@edx/paragon": "19.6.0",
         "@testing-library/dom": "7.31.2",
         "@testing-library/jest-dom": "5.16.2",
         "@testing-library/react": "10.4.9",
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^1.8.0",
-        "@edx/paragon": ">= ^7.0.0 < 17.0.0",
+        "@edx/paragon": ">= ^7.0.0 < 20.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0",
         "react-dom": "^16.9.0"
@@ -3143,9 +3143,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.14.9.tgz",
-      "integrity": "sha512-O/zcIGxga8gIjpZ4XWwgNNiN+2nXAAweSrWLMLT8tgICAEbCal7pM7b/0V9CvlxOmGKH+zj9cJHZQOAOIubpog==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.1.tgz",
+      "integrity": "sha512-vi2iG01z/mvlxKbgozGkZQTbchliq6MJ9tY4CpYy1CMjt5Rn/PDaS2sK6FKhuAlyQAR4ZqFWHrwM1wednG9RQQ==",
       "dev": true,
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
@@ -3171,7 +3171,7 @@
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
-        "@edx/paragon": ">= 10.0.0 < 17.0.0",
+        "@edx/paragon": ">= 10.0.0 < 20.0.0",
         "prop-types": "^15.7.2",
         "react": "^16.9.0",
         "react-dom": "^16.9.0",
@@ -3210,30 +3210,30 @@
       }
     },
     "node_modules/@edx/paragon": {
-      "version": "16.24.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.24.0.tgz",
-      "integrity": "sha512-LRm7acHjnYc7bTRLy0+LVYVS18Khk09YSNvHAx5/yOhXLK3lrtwNDOmERdnrsL/MURlSPACfzBnHTmG4NpfTpw==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.6.0.tgz",
+      "integrity": "sha512-Rl2Al7vgCEEmAK9EirZZXa1mRDnH9eOp+oi2sJPPksFDtj9gJw+PiGPzmMVojHGuRzOnE8rymNtiwpCa7lZYdg==",
       "dev": true,
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.30",
-        "@fortawesome/free-solid-svg-icons": "^5.14.0",
-        "@fortawesome/react-fontawesome": "^0.1.11",
-        "@popperjs/core": "^2.6.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.16",
+        "@popperjs/core": "^2.11.2",
         "airbnb-prop-types": "^2.12.0",
         "bootstrap": "4.6.0",
-        "classnames": "^2.2.6",
+        "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
         "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^1.3.0",
-        "react-focus-on": "^3.5.0",
-        "react-popper": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "react-bootstrap": "^1.6.4",
+        "react-focus-on": "^3.5.4",
+        "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^8.2.0",
-        "react-table": "^7.6.1",
-        "react-transition-group": "^4.0.0",
+        "react-table": "^7.7.0",
+        "react-transition-group": "^4.4.2",
         "tabbable": "^4.0.0",
         "uncontrollable": "7.2.1"
       },
@@ -5865,9 +5865,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
-      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -5906,9 +5906,9 @@
       }
     },
     "node_modules/@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
       "dev": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.0",
@@ -5967,9 +5967,9 @@
       "dev": true
     },
     "node_modules/@types/testing-library__jest-dom": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
-      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "version": "5.14.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+      "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
       "dev": true,
       "dependencies": {
         "@types/jest": "*"
@@ -6052,9 +6052,9 @@
       }
     },
     "node_modules/@types/yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -9121,40 +9121,40 @@
       }
     },
     "node_modules/cssnano-preset-default": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.12.tgz",
-      "integrity": "sha512-rO/JZYyjW1QNkWBxMGV28DW7d98UDLaF759frhli58QFehZ+D/LSmwQ2z/ylBAe2hUlsIWTq6NYGfQPq65EF9w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
+      "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
       "dev": true,
       "dependencies": {
         "css-declaration-sorter": "^6.0.3",
-        "cssnano-utils": "^3.0.2",
-        "postcss-calc": "^8.2.0",
-        "postcss-colormin": "^5.2.5",
-        "postcss-convert-values": "^5.0.4",
-        "postcss-discard-comments": "^5.0.3",
-        "postcss-discard-duplicates": "^5.0.3",
-        "postcss-discard-empty": "^5.0.3",
-        "postcss-discard-overridden": "^5.0.4",
-        "postcss-merge-longhand": "^5.0.6",
-        "postcss-merge-rules": "^5.0.6",
-        "postcss-minify-font-values": "^5.0.4",
-        "postcss-minify-gradients": "^5.0.6",
-        "postcss-minify-params": "^5.0.5",
-        "postcss-minify-selectors": "^5.1.3",
-        "postcss-normalize-charset": "^5.0.3",
-        "postcss-normalize-display-values": "^5.0.3",
-        "postcss-normalize-positions": "^5.0.4",
-        "postcss-normalize-repeat-style": "^5.0.4",
-        "postcss-normalize-string": "^5.0.4",
-        "postcss-normalize-timing-functions": "^5.0.3",
-        "postcss-normalize-unicode": "^5.0.4",
-        "postcss-normalize-url": "^5.0.5",
-        "postcss-normalize-whitespace": "^5.0.4",
-        "postcss-ordered-values": "^5.0.5",
-        "postcss-reduce-initial": "^5.0.3",
-        "postcss-reduce-transforms": "^5.0.4",
-        "postcss-svgo": "^5.0.4",
-        "postcss-unique-selectors": "^5.0.4"
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.0",
+        "postcss-convert-values": "^5.1.0",
+        "postcss-discard-comments": "^5.1.0",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.0",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.0",
+        "postcss-merge-rules": "^5.1.0",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.0",
+        "postcss-minify-params": "^5.1.0",
+        "postcss-minify-selectors": "^5.2.0",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.0",
+        "postcss-normalize-repeat-style": "^5.1.0",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.0",
+        "postcss-ordered-values": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -9164,9 +9164,9 @@
       }
     },
     "node_modules/cssnano-utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.0.2.tgz",
-      "integrity": "sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -9212,9 +9212,9 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "node_modules/cwebp-bin": {
       "version": "7.0.1",
@@ -9877,9 +9877,9 @@
       }
     },
     "node_modules/dom-accessibility-api": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.12.tgz",
-      "integrity": "sha512-gQ2mON6fLWZeM8ubjzL7RtMeHS/g8hb82j4MjHmcQECD7pevWsMlhqwp9BjIRrQvmyJMMyv/XiO1cXzeFlUw4g==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
       "dev": true
     },
     "node_modules/dom-converter": {
@@ -10124,9 +10124,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
+      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
       "dev": true
     },
     "node_modules/email-prop-type": {
@@ -10193,9 +10193,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
-      "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -12808,9 +12808,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
       "engines": {
         "node": ">= 0.4"
@@ -20937,9 +20937,9 @@
       }
     },
     "node_modules/postcss-colormin": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.5.tgz",
-      "integrity": "sha512-+X30aDaGYq81mFqwyPpnYInsZQnNpdxMX0ajlY7AExCexEFkPVV+KrO7kXwayqEWL2xwEbNQ4nUO0ZsRWGnevg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -20955,9 +20955,9 @@
       }
     },
     "node_modules/postcss-convert-values": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.4.tgz",
-      "integrity": "sha512-bugzSAyjIexdObovsPZu/sBCTHccImJxLyFgeV0MmNBm/Lw5h5XnjfML6gzEmJ3A6nyfCW7hb1JXzcsA4Zfbdw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
+      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -20970,9 +20970,9 @@
       }
     },
     "node_modules/postcss-discard-comments": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz",
-      "integrity": "sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
+      "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -20982,9 +20982,9 @@
       }
     },
     "node_modules/postcss-discard-duplicates": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz",
-      "integrity": "sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -20994,9 +20994,9 @@
       }
     },
     "node_modules/postcss-discard-empty": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz",
-      "integrity": "sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
+      "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -21006,9 +21006,9 @@
       }
     },
     "node_modules/postcss-discard-overridden": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz",
-      "integrity": "sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -21073,13 +21073,13 @@
       "dev": true
     },
     "node_modules/postcss-merge-longhand": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.6.tgz",
-      "integrity": "sha512-rkmoPwQO6ymJSmWsX6l2hHeEBQa7C4kJb9jyi5fZB1sE8nSCv7sqchoYPixRwX/yvLoZP2y6FA5kcjiByeJqDg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
+      "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.0.3"
+        "stylehacks": "^5.1.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -21089,14 +21089,14 @@
       }
     },
     "node_modules/postcss-merge-rules": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.6.tgz",
-      "integrity": "sha512-nzJWJ9yXWp8AOEpn/HFAW72WKVGD2bsLiAmgw4hDchSij27bt6TF+sIK0cJUBAYT3SGcjtGGsOR89bwkkMuMgQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
+      "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
       },
       "engines": {
@@ -21107,9 +21107,9 @@
       }
     },
     "node_modules/postcss-minify-font-values": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.4.tgz",
-      "integrity": "sha512-RN6q3tyuEesvyCYYFCRGJ41J1XFvgV+dvYGHr0CeHv8F00yILlN8Slf4t8XW4IghlfZYCeyRrANO6HpJ948ieA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21122,13 +21122,13 @@
       }
     },
     "node_modules/postcss-minify-gradients": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.6.tgz",
-      "integrity": "sha512-E/dT6oVxB9nLGUTiY/rG5dX9taugv9cbLNTFad3dKxOO+BQg25Q/xo2z2ddG+ZB1CbkZYaVwx5blY8VC7R/43A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
+      "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
       "dev": true,
       "dependencies": {
         "colord": "^2.9.1",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -21139,13 +21139,13 @@
       }
     },
     "node_modules/postcss-minify-params": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.5.tgz",
-      "integrity": "sha512-YBNuq3Rz5LfLFNHb9wrvm6t859b8qIqfXsWeK7wROm3jSKNpO1Y5e8cOyBv6Acji15TgSrAwb3JkVNCqNyLvBg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
+      "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -21156,9 +21156,9 @@
       }
     },
     "node_modules/postcss-minify-selectors": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.3.tgz",
-      "integrity": "sha512-9RJfTiQEKA/kZhMaEXND893nBqmYQ8qYa/G+uPdVnXF6D/FzpfI6kwBtWEcHx5FqDbA79O9n6fQJfrIj6M8jvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
+      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
       "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.5"
@@ -21230,9 +21230,9 @@
       }
     },
     "node_modules/postcss-normalize-charset": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz",
-      "integrity": "sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
       "dev": true,
       "engines": {
         "node": "^10 || ^12 || >=14.0"
@@ -21242,9 +21242,9 @@
       }
     },
     "node_modules/postcss-normalize-display-values": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.3.tgz",
-      "integrity": "sha512-FIV5FY/qs4Ja32jiDb5mVj5iWBlS3N8tFcw2yg98+8MkRgyhtnBgSC0lxU+16AMHbjX5fbSJgw5AXLMolonuRQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21257,9 +21257,9 @@
       }
     },
     "node_modules/postcss-normalize-positions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.4.tgz",
-      "integrity": "sha512-qynirjBX0Lc73ROomZE3lzzmXXTu48/QiEzKgMeqh28+MfuHLsuqC9po4kj84igZqqFGovz8F8hf44hA3dPYmQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
+      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21272,9 +21272,9 @@
       }
     },
     "node_modules/postcss-normalize-repeat-style": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.4.tgz",
-      "integrity": "sha512-Innt+wctD7YpfeDR7r5Ik6krdyppyAg2HBRpX88fo5AYzC1Ut/l3xaxACG0KsbX49cO2n5EB13clPwuYVt8cMA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
+      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21287,9 +21287,9 @@
       }
     },
     "node_modules/postcss-normalize-string": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.4.tgz",
-      "integrity": "sha512-Dfk42l0+A1CDnVpgE606ENvdmksttLynEqTQf5FL3XGQOyqxjbo25+pglCUvziicTxjtI2NLUR6KkxyUWEVubQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21302,9 +21302,9 @@
       }
     },
     "node_modules/postcss-normalize-timing-functions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.3.tgz",
-      "integrity": "sha512-QRfjvFh11moN4PYnJ7hia4uJXeFotyK3t2jjg8lM9mswleGsNw2Lm3I5wO+l4k1FzK96EFwEVn8X8Ojrp2gP4g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21317,9 +21317,9 @@
       }
     },
     "node_modules/postcss-normalize-unicode": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.4.tgz",
-      "integrity": "sha512-W79Regn+a+eXTzB+oV/8XJ33s3pDyFTND2yDuUCo0Xa3QSy1HtNIfRVPXNubHxjhlqmMFADr3FSCHT84ITW3ig==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -21333,9 +21333,9 @@
       }
     },
     "node_modules/postcss-normalize-url": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.5.tgz",
-      "integrity": "sha512-Ws3tX+PcekYlXh+ycAt0wyzqGthkvVtZ9SZLutMVvHARxcpu4o7vvXcNoiNKyjKuWecnjS6HDI3fjBuDr5MQxQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
       "dev": true,
       "dependencies": {
         "normalize-url": "^6.0.1",
@@ -21349,9 +21349,9 @@
       }
     },
     "node_modules/postcss-normalize-whitespace": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.4.tgz",
-      "integrity": "sha512-wsnuHolYZjMwWZJoTC9jeI2AcjA67v4UuidDrPN9RnX8KIZfE+r2Nd6XZRwHVwUiHmRvKQtxiqo64K+h8/imaw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
+      "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21364,12 +21364,12 @@
       }
     },
     "node_modules/postcss-ordered-values": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.5.tgz",
-      "integrity": "sha512-mfY7lXpq+8bDEHfP+muqibDPhZ5eP9zgBEF9XRvoQgXcQe2Db3G1wcvjbnfjXG6wYsl+0UIjikqq4ym1V2jGMQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
+      "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
       "dev": true,
       "dependencies": {
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       },
       "engines": {
@@ -21380,9 +21380,9 @@
       }
     },
     "node_modules/postcss-reduce-initial": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.3.tgz",
-      "integrity": "sha512-c88TkSnQ/Dnwgb4OZbKPOBbCaauwEjbECP5uAuFPOzQ+XdjNjRH7SG0dteXrpp1LlIFEKK76iUGgmw2V0xeieA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -21396,9 +21396,9 @@
       }
     },
     "node_modules/postcss-reduce-transforms": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.4.tgz",
-      "integrity": "sha512-VIJB9SFSaL8B/B7AXb7KHL6/GNNbbCHslgdzS9UDfBZYIA2nx8NLY7iD/BXFSO/1sRUILzBTfHCoW5inP37C5g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
@@ -21439,9 +21439,9 @@
       }
     },
     "node_modules/postcss-svgo": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.4.tgz",
-      "integrity": "sha512-yDKHvULbnZtIrRqhZoA+rxreWpee28JSRH/gy9727u0UCgtpv1M/9WEWY3xySlFa0zQJcqf6oCBJPR5NwkmYpg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
       "dev": true,
       "dependencies": {
         "postcss-value-parser": "^4.2.0",
@@ -21455,9 +21455,9 @@
       }
     },
     "node_modules/postcss-unique-selectors": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.4.tgz",
-      "integrity": "sha512-5ampwoSDJCxDPoANBIlMgoBcYUHnhaiuLYJR5pj1DLnYQvMRVyFuTA5C3Bvt+aHtiqWpJkD/lXT50Vo1D0ZsAQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
+      "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
       "dev": true,
       "dependencies": {
         "postcss-selector-parser": "^6.0.5"
@@ -24679,9 +24679,9 @@
       }
     },
     "node_modules/stylehacks": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.3.tgz",
-      "integrity": "sha512-ENcUdpf4yO0E1rubu8rkxI+JGQk4CgjchynZ4bDBJDfqdy+uhTRSWb8/F3Jtu+Bw5MW45Po3/aQGeIyyxgQtxg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.16.6",
@@ -25057,9 +25057,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
-      "integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+      "integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.5.0",
@@ -25420,9 +25420,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -29242,9 +29242,9 @@
       }
     },
     "@edx/frontend-platform": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.14.9.tgz",
-      "integrity": "sha512-O/zcIGxga8gIjpZ4XWwgNNiN+2nXAAweSrWLMLT8tgICAEbCal7pM7b/0V9CvlxOmGKH+zj9cJHZQOAOIubpog==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-1.15.1.tgz",
+      "integrity": "sha512-vi2iG01z/mvlxKbgozGkZQTbchliq6MJ9tY4CpYy1CMjt5Rn/PDaS2sK6FKhuAlyQAR4ZqFWHrwM1wednG9RQQ==",
       "dev": true,
       "requires": {
         "@cospired/i18n-iso-languages": "2.2.0",
@@ -29292,30 +29292,30 @@
       }
     },
     "@edx/paragon": {
-      "version": "16.24.0",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.24.0.tgz",
-      "integrity": "sha512-LRm7acHjnYc7bTRLy0+LVYVS18Khk09YSNvHAx5/yOhXLK3lrtwNDOmERdnrsL/MURlSPACfzBnHTmG4NpfTpw==",
+      "version": "19.6.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-19.6.0.tgz",
+      "integrity": "sha512-Rl2Al7vgCEEmAK9EirZZXa1mRDnH9eOp+oi2sJPPksFDtj9gJw+PiGPzmMVojHGuRzOnE8rymNtiwpCa7lZYdg==",
       "dev": true,
       "requires": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.30",
-        "@fortawesome/free-solid-svg-icons": "^5.14.0",
-        "@fortawesome/react-fontawesome": "^0.1.11",
-        "@popperjs/core": "^2.6.0",
+        "@fortawesome/fontawesome-svg-core": "^1.2.36",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
+        "@fortawesome/react-fontawesome": "^0.1.16",
+        "@popperjs/core": "^2.11.2",
         "airbnb-prop-types": "^2.12.0",
         "bootstrap": "4.6.0",
-        "classnames": "^2.2.6",
+        "classnames": "^2.3.1",
         "email-prop-type": "^3.0.0",
         "font-awesome": "^4.7.0",
         "lodash.uniqby": "^4.7.0",
         "mailto-link": "^1.0.0",
-        "prop-types": "^15.7.2",
-        "react-bootstrap": "^1.3.0",
-        "react-focus-on": "^3.5.0",
-        "react-popper": "^2.2.4",
+        "prop-types": "^15.8.1",
+        "react-bootstrap": "^1.6.4",
+        "react-focus-on": "^3.5.4",
+        "react-popper": "^2.2.5",
         "react-proptype-conditional-require": "^1.0.4",
         "react-responsive": "^8.2.0",
-        "react-table": "^7.6.1",
-        "react-transition-group": "^4.0.0",
+        "react-table": "^7.7.0",
+        "react-transition-group": "^4.4.2",
         "tabbable": "^4.0.0",
         "uncontrollable": "7.2.1"
       }
@@ -31299,9 +31299,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
-      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -31340,9 +31340,9 @@
       }
     },
     "@types/react-redux": {
-      "version": "7.1.22",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.22.tgz",
-      "integrity": "sha512-GxIA1kM7ClU73I6wg9IRTVwSO9GS+SAKZKe0Enj+82HMU6aoESFU2HNAdNi3+J53IaOHPiUfT3kSG4L828joDQ==",
+      "version": "7.1.23",
+      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
+      "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
       "dev": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.0",
@@ -31400,9 +31400,9 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.14.2",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.2.tgz",
-      "integrity": "sha512-vehbtyHUShPxIa9SioxDwCvgxukDMH//icJG90sXQBUm5lJOHLT5kNeU9tnivhnA/TkOFMzGIXN2cTc4hY8/kg==",
+      "version": "5.14.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
+      "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
@@ -31482,9 +31482,9 @@
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.1",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
-      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -33909,46 +33909,46 @@
       }
     },
     "cssnano-preset-default": {
-      "version": "5.1.12",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.1.12.tgz",
-      "integrity": "sha512-rO/JZYyjW1QNkWBxMGV28DW7d98UDLaF759frhli58QFehZ+D/LSmwQ2z/ylBAe2hUlsIWTq6NYGfQPq65EF9w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-5.2.0.tgz",
+      "integrity": "sha512-3N5Vcptj2pqVKpHVqH6ezOJvqikR2PdLTbTrsrhF61FbLRQuujAqZ2sKN5rvcMsb7hFjrNnjZT8CGEkxoN/Pwg==",
       "dev": true,
       "requires": {
         "css-declaration-sorter": "^6.0.3",
-        "cssnano-utils": "^3.0.2",
-        "postcss-calc": "^8.2.0",
-        "postcss-colormin": "^5.2.5",
-        "postcss-convert-values": "^5.0.4",
-        "postcss-discard-comments": "^5.0.3",
-        "postcss-discard-duplicates": "^5.0.3",
-        "postcss-discard-empty": "^5.0.3",
-        "postcss-discard-overridden": "^5.0.4",
-        "postcss-merge-longhand": "^5.0.6",
-        "postcss-merge-rules": "^5.0.6",
-        "postcss-minify-font-values": "^5.0.4",
-        "postcss-minify-gradients": "^5.0.6",
-        "postcss-minify-params": "^5.0.5",
-        "postcss-minify-selectors": "^5.1.3",
-        "postcss-normalize-charset": "^5.0.3",
-        "postcss-normalize-display-values": "^5.0.3",
-        "postcss-normalize-positions": "^5.0.4",
-        "postcss-normalize-repeat-style": "^5.0.4",
-        "postcss-normalize-string": "^5.0.4",
-        "postcss-normalize-timing-functions": "^5.0.3",
-        "postcss-normalize-unicode": "^5.0.4",
-        "postcss-normalize-url": "^5.0.5",
-        "postcss-normalize-whitespace": "^5.0.4",
-        "postcss-ordered-values": "^5.0.5",
-        "postcss-reduce-initial": "^5.0.3",
-        "postcss-reduce-transforms": "^5.0.4",
-        "postcss-svgo": "^5.0.4",
-        "postcss-unique-selectors": "^5.0.4"
+        "cssnano-utils": "^3.1.0",
+        "postcss-calc": "^8.2.3",
+        "postcss-colormin": "^5.3.0",
+        "postcss-convert-values": "^5.1.0",
+        "postcss-discard-comments": "^5.1.0",
+        "postcss-discard-duplicates": "^5.1.0",
+        "postcss-discard-empty": "^5.1.0",
+        "postcss-discard-overridden": "^5.1.0",
+        "postcss-merge-longhand": "^5.1.0",
+        "postcss-merge-rules": "^5.1.0",
+        "postcss-minify-font-values": "^5.1.0",
+        "postcss-minify-gradients": "^5.1.0",
+        "postcss-minify-params": "^5.1.0",
+        "postcss-minify-selectors": "^5.2.0",
+        "postcss-normalize-charset": "^5.1.0",
+        "postcss-normalize-display-values": "^5.1.0",
+        "postcss-normalize-positions": "^5.1.0",
+        "postcss-normalize-repeat-style": "^5.1.0",
+        "postcss-normalize-string": "^5.1.0",
+        "postcss-normalize-timing-functions": "^5.1.0",
+        "postcss-normalize-unicode": "^5.1.0",
+        "postcss-normalize-url": "^5.1.0",
+        "postcss-normalize-whitespace": "^5.1.0",
+        "postcss-ordered-values": "^5.1.0",
+        "postcss-reduce-initial": "^5.1.0",
+        "postcss-reduce-transforms": "^5.1.0",
+        "postcss-svgo": "^5.1.0",
+        "postcss-unique-selectors": "^5.1.0"
       }
     },
     "cssnano-utils": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.0.2.tgz",
-      "integrity": "sha512-KhprijuQv2sP4kT92sSQwhlK3SJTbDIsxcfIEySB0O+3m9esFOai7dP9bMx5enHAh2MwarVIcnwiWoOm01RIbQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
+      "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
       "dev": true,
       "requires": {}
     },
@@ -33985,9 +33985,9 @@
       }
     },
     "csstype": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
-      "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
+      "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw=="
     },
     "cwebp-bin": {
       "version": "7.0.1",
@@ -34503,9 +34503,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.12.tgz",
-      "integrity": "sha512-gQ2mON6fLWZeM8ubjzL7RtMeHS/g8hb82j4MjHmcQECD7pevWsMlhqwp9BjIRrQvmyJMMyv/XiO1cXzeFlUw4g==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
+      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
       "dev": true
     },
     "dom-converter": {
@@ -34701,9 +34701,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.71",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
-      "integrity": "sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==",
+      "version": "1.4.75",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.75.tgz",
+      "integrity": "sha512-LxgUNeu3BVU7sXaKjUDD9xivocQLxFtq6wgERrutdY/yIOps3ODOZExK1jg8DTEg4U8TUCb5MLGeWFOYuxjF3Q==",
       "dev": true
     },
     "email-prop-type": {
@@ -34755,9 +34755,9 @@
       }
     },
     "enhanced-resolve": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
-      "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.2.tgz",
+      "integrity": "sha512-GIm3fQfwLJ8YZx2smuHpBKkXC1yOk+OBEmKckVyL0i/ea8mqDEykK3ld5dgH1QYPNyT/lIllxV2LULnxCHaHkA==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.2.4",
@@ -36761,9 +36761,9 @@
       "optional": true
     },
     "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true
     },
     "has-to-string-tag-x": {
@@ -42943,9 +42943,9 @@
       }
     },
     "postcss-colormin": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.2.5.tgz",
-      "integrity": "sha512-+X30aDaGYq81mFqwyPpnYInsZQnNpdxMX0ajlY7AExCexEFkPVV+KrO7kXwayqEWL2xwEbNQ4nUO0ZsRWGnevg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-5.3.0.tgz",
+      "integrity": "sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -42955,39 +42955,39 @@
       }
     },
     "postcss-convert-values": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.0.4.tgz",
-      "integrity": "sha512-bugzSAyjIexdObovsPZu/sBCTHccImJxLyFgeV0MmNBm/Lw5h5XnjfML6gzEmJ3A6nyfCW7hb1JXzcsA4Zfbdw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-5.1.0.tgz",
+      "integrity": "sha512-GkyPbZEYJiWtQB0KZ0X6qusqFHUepguBCNFi9t5JJc7I2OTXG7C0twbTLvCfaKOLl3rSXmpAwV7W5txd91V84g==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-discard-comments": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.0.3.tgz",
-      "integrity": "sha512-6W5BemziRoqIdAKT+1QjM4bNcJAQ7z7zk073730NHg4cUXh3/rQHHj7pmYxUB9aGhuRhBiUf0pXvIHkRwhQP0Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.0.tgz",
+      "integrity": "sha512-L0IKF4jAshRyn03SkEO6ar/Ipz2oLywVbg2THf2EqqdNkBwmVMxuTR/RoAltOw4piiaLt3gCAdrbAqmTBInmhg==",
       "dev": true,
       "requires": {}
     },
     "postcss-discard-duplicates": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.0.3.tgz",
-      "integrity": "sha512-vPtm1Mf+kp7iAENTG7jI1MN1lk+fBqL5y+qxyi4v3H+lzsXEdfS3dwUZD45KVhgzDEgduur8ycB4hMegyMTeRw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
+      "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
       "dev": true,
       "requires": {}
     },
     "postcss-discard-empty": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.0.3.tgz",
-      "integrity": "sha512-xGJugpaXKakwKI7sSdZjUuN4V3zSzb2Y0LOlmTajFbNinEjTfVs9PFW2lmKBaC/E64WwYppfqLD03P8l9BuueA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.0.tgz",
+      "integrity": "sha512-782T/buGgb3HOuHOJAHpdyKzAAKsv/BxWqsutnZ+QsiHEcDkY7v+6WWdturuBiSal6XMOO1p1aJvwXdqLD5vhA==",
       "dev": true,
       "requires": {}
     },
     "postcss-discard-overridden": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.0.4.tgz",
-      "integrity": "sha512-3j9QH0Qh1KkdxwiZOW82cId7zdwXVQv/gRXYDnwx5pBtR1sTkU4cXRK9lp5dSdiM0r0OICO/L8J6sV1/7m0kHg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
+      "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
       "dev": true,
       "requires": {}
     },
@@ -43029,62 +43029,62 @@
       }
     },
     "postcss-merge-longhand": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.0.6.tgz",
-      "integrity": "sha512-rkmoPwQO6ymJSmWsX6l2hHeEBQa7C4kJb9jyi5fZB1sE8nSCv7sqchoYPixRwX/yvLoZP2y6FA5kcjiByeJqDg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-5.1.0.tgz",
+      "integrity": "sha512-Gr46srN2tsLD8fudKYoHO56RG0BLQ2nsBRnSZGY04eNBPwTeWa9KeHrbL3tOLAHyB2aliikycPH2TMJG1U+W6g==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0",
-        "stylehacks": "^5.0.3"
+        "stylehacks": "^5.1.0"
       }
     },
     "postcss-merge-rules": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.0.6.tgz",
-      "integrity": "sha512-nzJWJ9yXWp8AOEpn/HFAW72WKVGD2bsLiAmgw4hDchSij27bt6TF+sIK0cJUBAYT3SGcjtGGsOR89bwkkMuMgQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-5.1.0.tgz",
+      "integrity": "sha512-NecukEJovQ0mG7h7xV8wbYAkXGTO3MPKnXvuiXzOKcxoOodfTTKYjeo8TMhAswlSkjcPIBlnKbSFcTuVSDaPyQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
         "caniuse-api": "^3.0.0",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-selector-parser": "^6.0.5"
       }
     },
     "postcss-minify-font-values": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.0.4.tgz",
-      "integrity": "sha512-RN6q3tyuEesvyCYYFCRGJ41J1XFvgV+dvYGHr0CeHv8F00yILlN8Slf4t8XW4IghlfZYCeyRrANO6HpJ948ieA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-5.1.0.tgz",
+      "integrity": "sha512-el3mYTgx13ZAPPirSVsHqFzl+BBBDrXvbySvPGFnQcTI4iNslrPaFq4muTkLZmKlGk4gyFAYUBMH30+HurREyA==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-minify-gradients": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.0.6.tgz",
-      "integrity": "sha512-E/dT6oVxB9nLGUTiY/rG5dX9taugv9cbLNTFad3dKxOO+BQg25Q/xo2z2ddG+ZB1CbkZYaVwx5blY8VC7R/43A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-5.1.0.tgz",
+      "integrity": "sha512-J/TMLklkONn3LuL8wCwfwU8zKC1hpS6VcxFkNUNjmVt53uKqrrykR3ov11mdUYyqVMEx67slMce0tE14cE4DTg==",
       "dev": true,
       "requires": {
         "colord": "^2.9.1",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-minify-params": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.0.5.tgz",
-      "integrity": "sha512-YBNuq3Rz5LfLFNHb9wrvm6t859b8qIqfXsWeK7wROm3jSKNpO1Y5e8cOyBv6Acji15TgSrAwb3JkVNCqNyLvBg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-5.1.0.tgz",
+      "integrity": "sha512-q67dcts4Hct6x8+JmhBgctHkbvUsqGIg2IItenjE63iZXMbhjr7AlVZkNnKtIGt/1Wsv7p/7YzeSII6Q+KPXRg==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-minify-selectors": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.1.3.tgz",
-      "integrity": "sha512-9RJfTiQEKA/kZhMaEXND893nBqmYQ8qYa/G+uPdVnXF6D/FzpfI6kwBtWEcHx5FqDbA79O9n6fQJfrIj6M8jvQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-5.2.0.tgz",
+      "integrity": "sha512-vYxvHkW+iULstA+ctVNx0VoRAR4THQQRkG77o0oa4/mBS0OzGvvzLIvHDv/nNEM0crzN2WIyFU5X7wZhaUK3RA==",
       "dev": true,
       "requires": {
         "postcss-selector-parser": "^6.0.5"
@@ -43127,61 +43127,61 @@
       }
     },
     "postcss-normalize-charset": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.0.3.tgz",
-      "integrity": "sha512-iKEplDBco9EfH7sx4ut7R2r/dwTnUqyfACf62Unc9UiyFuI7uUqZZtY+u+qp7g8Qszl/U28HIfcsI3pEABWFfA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
+      "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
       "dev": true,
       "requires": {}
     },
     "postcss-normalize-display-values": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.0.3.tgz",
-      "integrity": "sha512-FIV5FY/qs4Ja32jiDb5mVj5iWBlS3N8tFcw2yg98+8MkRgyhtnBgSC0lxU+16AMHbjX5fbSJgw5AXLMolonuRQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-5.1.0.tgz",
+      "integrity": "sha512-WP4KIM4o2dazQXWmFaqMmcvsKmhdINFblgSeRgn8BJ6vxaMyaJkwAzpPpuvSIoG/rmX3M+IrRZEz2H0glrQNEA==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-positions": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.0.4.tgz",
-      "integrity": "sha512-qynirjBX0Lc73ROomZE3lzzmXXTu48/QiEzKgMeqh28+MfuHLsuqC9po4kj84igZqqFGovz8F8hf44hA3dPYmQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-5.1.0.tgz",
+      "integrity": "sha512-8gmItgA4H5xiUxgN/3TVvXRoJxkAWLW6f/KKhdsH03atg0cB8ilXnrB5PpSshwVu/dD2ZsRFQcR1OEmSBDAgcQ==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-repeat-style": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.0.4.tgz",
-      "integrity": "sha512-Innt+wctD7YpfeDR7r5Ik6krdyppyAg2HBRpX88fo5AYzC1Ut/l3xaxACG0KsbX49cO2n5EB13clPwuYVt8cMA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-5.1.0.tgz",
+      "integrity": "sha512-IR3uBjc+7mcWGL6CtniKNQ4Rr5fTxwkaDHwMBDGGs1x9IVRkYIT/M4NelZWkAOBdV6v3Z9S46zqaKGlyzHSchw==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-string": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.0.4.tgz",
-      "integrity": "sha512-Dfk42l0+A1CDnVpgE606ENvdmksttLynEqTQf5FL3XGQOyqxjbo25+pglCUvziicTxjtI2NLUR6KkxyUWEVubQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-5.1.0.tgz",
+      "integrity": "sha512-oYiIJOf4T9T1N4i+abeIc7Vgm/xPCGih4bZz5Nm0/ARVJ7K6xrDlLwvwqOydvyL3RHNf8qZk6vo3aatiw/go3w==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-timing-functions": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.0.3.tgz",
-      "integrity": "sha512-QRfjvFh11moN4PYnJ7hia4uJXeFotyK3t2jjg8lM9mswleGsNw2Lm3I5wO+l4k1FzK96EFwEVn8X8Ojrp2gP4g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-5.1.0.tgz",
+      "integrity": "sha512-DOEkzJ4SAXv5xkHl0Wa9cZLF3WCBhF3o1SKVxKQAa+0pYKlueTpCgvkFAHfk+Y64ezX9+nITGrDZeVGgITJXjg==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-normalize-unicode": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.0.4.tgz",
-      "integrity": "sha512-W79Regn+a+eXTzB+oV/8XJ33s3pDyFTND2yDuUCo0Xa3QSy1HtNIfRVPXNubHxjhlqmMFADr3FSCHT84ITW3ig==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-5.1.0.tgz",
+      "integrity": "sha512-J6M3MizAAZ2dOdSjy2caayJLQT8E8K9XjLce8AUQMwOrCvjCHv24aLC/Lps1R1ylOfol5VIDMaM/Lo9NGlk1SQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -43189,9 +43189,9 @@
       }
     },
     "postcss-normalize-url": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.0.5.tgz",
-      "integrity": "sha512-Ws3tX+PcekYlXh+ycAt0wyzqGthkvVtZ9SZLutMVvHARxcpu4o7vvXcNoiNKyjKuWecnjS6HDI3fjBuDr5MQxQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-5.1.0.tgz",
+      "integrity": "sha512-5upGeDO+PVthOxSmds43ZeMeZfKH+/DKgGRD7TElkkyS46JXAUhMzIKiCa7BabPeIy3AQcTkXwVVN7DbqsiCew==",
       "dev": true,
       "requires": {
         "normalize-url": "^6.0.1",
@@ -43199,28 +43199,28 @@
       }
     },
     "postcss-normalize-whitespace": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.0.4.tgz",
-      "integrity": "sha512-wsnuHolYZjMwWZJoTC9jeI2AcjA67v4UuidDrPN9RnX8KIZfE+r2Nd6XZRwHVwUiHmRvKQtxiqo64K+h8/imaw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-5.1.0.tgz",
+      "integrity": "sha512-7O1FanKaJkpWFyCghFzIkLhehujV/frGkdofGLwhg5upbLyGsSfiTcZAdSzoPsSUgyPCkBkNMeWR8yVgPdQybg==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-ordered-values": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.0.5.tgz",
-      "integrity": "sha512-mfY7lXpq+8bDEHfP+muqibDPhZ5eP9zgBEF9XRvoQgXcQe2Db3G1wcvjbnfjXG6wYsl+0UIjikqq4ym1V2jGMQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-5.1.0.tgz",
+      "integrity": "sha512-wU4Z4D4uOIH+BUKkYid36gGDJNQtkVJT7Twv8qH6UyfttbbJWyw4/xIPuVEkkCtQLAJ0EdsNSh8dlvqkXb49TA==",
       "dev": true,
       "requires": {
-        "cssnano-utils": "^3.0.2",
+        "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
       }
     },
     "postcss-reduce-initial": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.0.3.tgz",
-      "integrity": "sha512-c88TkSnQ/Dnwgb4OZbKPOBbCaauwEjbECP5uAuFPOzQ+XdjNjRH7SG0dteXrpp1LlIFEKK76iUGgmw2V0xeieA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.0.tgz",
+      "integrity": "sha512-5OgTUviz0aeH6MtBjHfbr57tml13PuedK/Ecg8szzd4XRMbYxH4572JFG067z+FqBIf6Zp/d+0581glkvvWMFw==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -43228,9 +43228,9 @@
       }
     },
     "postcss-reduce-transforms": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.0.4.tgz",
-      "integrity": "sha512-VIJB9SFSaL8B/B7AXb7KHL6/GNNbbCHslgdzS9UDfBZYIA2nx8NLY7iD/BXFSO/1sRUILzBTfHCoW5inP37C5g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-5.1.0.tgz",
+      "integrity": "sha512-2fbdbmgir5AvpW9RLtdONx1QoYG2/EtqpNQbFASDlixBbAYuTcJ0dECwlqNqH7VbaUnEnh8SrxOe2sRIn24XyQ==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0"
@@ -43256,9 +43256,9 @@
       }
     },
     "postcss-svgo": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.0.4.tgz",
-      "integrity": "sha512-yDKHvULbnZtIrRqhZoA+rxreWpee28JSRH/gy9727u0UCgtpv1M/9WEWY3xySlFa0zQJcqf6oCBJPR5NwkmYpg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-5.1.0.tgz",
+      "integrity": "sha512-D75KsH1zm5ZrHyxPakAxJWtkyXew5qwS70v56exwvw542d9CRtTo78K0WeFxZB4G7JXKKMbEZtZayTGdIky/eA==",
       "dev": true,
       "requires": {
         "postcss-value-parser": "^4.2.0",
@@ -43266,9 +43266,9 @@
       }
     },
     "postcss-unique-selectors": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.0.4.tgz",
-      "integrity": "sha512-5ampwoSDJCxDPoANBIlMgoBcYUHnhaiuLYJR5pj1DLnYQvMRVyFuTA5C3Bvt+aHtiqWpJkD/lXT50Vo1D0ZsAQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-5.1.0.tgz",
+      "integrity": "sha512-LmUhgGobtpeVJJHuogzjLRwJlN7VH+BL5c9GKMVJSS/ejoyePZkXvNsYUtk//F6vKOGK86gfRS0xH7fXQSDtvA==",
       "dev": true,
       "requires": {
         "postcss-selector-parser": "^6.0.5"
@@ -45830,9 +45830,9 @@
       }
     },
     "stylehacks": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.0.3.tgz",
-      "integrity": "sha512-ENcUdpf4yO0E1rubu8rkxI+JGQk4CgjchynZ4bDBJDfqdy+uhTRSWb8/F3Jtu+Bw5MW45Po3/aQGeIyyxgQtxg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-5.1.0.tgz",
+      "integrity": "sha512-SzLmvHQTrIWfSgljkQCw2++C9+Ne91d/6Sp92I8c5uHTcy/PgeHamwITIbBW9wnFTY/3ZfSXR9HIL6Ikqmcu6Q==",
       "dev": true,
       "requires": {
         "browserslist": "^4.16.6",
@@ -46122,9 +46122,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.11.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.11.0.tgz",
-          "integrity": "sha512-uCA9DLanzzWSsN1UirKwylhhRz3aKPInlfmpGfw8VN6jHsAtu8HJtIpeeHHK23rxnE/cDc+yvmq5wqkIC6Kn0A==",
+          "version": "5.12.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.12.0.tgz",
+          "integrity": "sha512-R3AUhNBGWiFc77HXag+1fXpAxTAFRQTJemlJKjAgD9r8xXTpjNKqIXwHM/o7Rh+O0kUJtS3WQVdBeMKFk5sw9A==",
           "dev": true,
           "requires": {
             "acorn": "^8.5.0",
@@ -46408,9 +46408,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
-      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "typescript-compare": {

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "devDependencies": {
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-build": "9.1.1",
-    "@edx/frontend-platform": "1.14.9",
-    "@edx/paragon": "^16.0.0",
+    "@edx/frontend-platform": "1.15.1",
+    "@edx/paragon": "19.6.0",
     "codecov": "3.8.3",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^1.8.0",
-    "@edx/paragon": ">= ^7.0.0 < 17.0.0",
+    "@edx/paragon": ">= ^7.0.0 < 20.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
We've added Node 16 support in this repo but Paragon version being used in this repo doesn't support Node 16 so upgraded  it to latest version