### PR TITLE
feat: Added package-lock file version check

### DIFF
--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -1,0 +1,14 @@
+#check package-lock file version
+
+name: lockfileVersion check
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+
+jobs:
+  version-check:
+    uses: Jawayria/.github/.github/workflows/lockfileversion-check.yml@jawayria/pkg-lock-check
+    

--- a/.github/workflows/lockfileversion-check.yml
+++ b/.github/workflows/lockfileversion-check.yml
@@ -10,5 +10,5 @@ on:
 
 jobs:
   version-check:
-    uses: Jawayria/.github/.github/workflows/lockfileversion-check.yml@jawayria/pkg-lock-check
+    uses: openedx/.github/.github/workflows/lockfileversion-check.yml@master
     


### PR DESCRIPTION
lockfileVersion value for the package-lock.json generated by NPM6 is 1 but now as we've moved to Node16 and NPM8, package-lock.json should be generated using NPM8. lockfileVersion for package-lock.json generated using NPM8 is 2. So here we're going to check the lockfileVersion in package-lock.json in order to verify that dependencies were installed using NPM8.