### PR TITLE
chore: updating paragon dependecy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^2.0.0",
-        "@edx/paragon": ">= 7.0.0 < 20.0.0",
+        "@edx/paragon": ">= 7.0.0 < 21.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0",
         "react-dom": "^16.9.0"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^2.0.0",
-    "@edx/paragon": ">= 7.0.0 < 20.0.0",
+    "@edx/paragon": ">= 7.0.0 < 21.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",
     "react-dom": "^16.9.0"


### PR DESCRIPTION
Updating Paragon dependency so we can use versions over 20.0.0 in other MFEs. In this case, I am updating the dependencies of frontend-app-enterprise-public-catalog ([associated ticket here](https://2u-internal.atlassian.net/jira/software/c/projects/ENT/boards/630)) and am running into problems. 