### PR TITLE
fix: Add transifex flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ push_translations:
 
 # Pulls translations from Transifex.
 pull_translations:
-	tx pull -f --mode reviewed --languages=$(transifex_langs)
+	tx pull -t -f --mode reviewed --languages=$(transifex_langs)
 
 # This target is used by Travis.
 validate-no-uncommitted-package-lock-changes:


### PR DESCRIPTION
The Transifex cli started requiring the -t or --translations flag in the pull command in order to fetch translations.

https://github.com/edx/edx-arch-experiments/issues/77