### PR TITLE
fix: Change frontend-platform peer dependency to v2 or v3 range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "redux-saga": "1.2.1"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^3.0.0",
+        "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
         "@edx/paragon": ">= 7.0.0 < 21.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-transition-group": "4.4.5"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^3.0.0",
+    "@edx/frontend-platform": "^2.0.0 || ^3.0.0",
     "@edx/paragon": ">= 7.0.0 < 21.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0",


### PR DESCRIPTION
[REV-3174](https://2u-internal.atlassian.net/browse/REV-3174).

Keeping consistency with https://github.com/openedx/frontend-component-footer/pull/250, adding a range to avoid peer dependency issues with the v3 upgrade.