### PR TITLE
chore(deps): update frontend-platform version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-semantically-released",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/frontend-platform": "^4.0.1",
+        "@edx/frontend-platform": "^4.1.0",
         "@edx/paragon": "20.30.1",
         "@fortawesome/fontawesome-svg-core": "6.3.0",
         "@fortawesome/free-brands-svg-icons": "6.3.0",
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/@edx/frontend-platform": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.0.2.tgz",
-      "integrity": "sha512-Ee4ElMiozydlGv/71fMlxZntOPt23Pe69lcD9beWWDtH1Qe+vGGzBxfWnA3iH1X1zGDD23HxQYvm1bgafmuEDw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-platform/-/frontend-platform-4.1.0.tgz",
+      "integrity": "sha512-7RzN68zaGJS3JZ2UJNx9UTz/qt+TqPAaF9+ngUEhF1iuZCBqoxW2tSg6splHlzXtW9Xk4xBmx5IbssoZWf57iw==",
       "dependencies": {
         "@cospired/i18n-iso-languages": "2.2.0",
         "@formatjs/intl-pluralrules": "4.3.3",
@@ -3140,13 +3140,14 @@
         "universal-cookie": "4.0.4"
       },
       "bin": {
+        "intl-imports.js": "i18n/scripts/intl-imports.js",
         "transifex-utils.js": "i18n/scripts/transifex-utils.js"
       },
       "peerDependencies": {
         "@edx/paragon": ">= 10.0.0 < 21.0.0",
         "prop-types": "^15.7.2",
-        "react": "^16.9.0",
-        "react-dom": "^16.9.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
         "react-redux": "^7.1.1",
         "react-router-dom": "^5.0.1",
         "redux": "^4.0.4"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "redux-saga": "1.2.3"
   },
   "dependencies": {
-    "@edx/frontend-platform": "^4.0.1",
+    "@edx/frontend-platform": "^4.1.0",
     "@edx/paragon": "20.30.1",
     "@fortawesome/fontawesome-svg-core": "6.3.0",
     "@fortawesome/free-brands-svg-icons": "6.3.0",


### PR DESCRIPTION
Adds the intl-imports.js script for FC-0012 OEP-58.

No manual testing has been done.

 - Related PR: https://github.com/openedx/frontend-app-learning/pull/1093

References
----------

This pull request is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern.