### PR TITLE
fix: clicking on notification redirecting to correct URL

### DIFF
--- a/src/Notifications/NotificationRowItem.jsx
+++ b/src/Notifications/NotificationRowItem.jsx
@@ -3,7 +3,6 @@ import { useDispatch } from 'react-redux';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import PropTypes from 'prop-types';
 import { Icon } from '@edx/paragon';
-import { Link } from 'react-router-dom';
 import * as timeago from 'timeago.js';
 import { getIconByType } from './utils';
 import { markNotificationsAsRead } from './data/thunks';
@@ -24,12 +23,13 @@ const NotificationRowItem = ({
   const { icon: iconComponent, class: iconClass } = getIconByType(type);
 
   return (
-    <Link
+    <a
       target="_blank"
       className="d-flex mb-2 align-items-center text-decoration-none"
-      to={contentUrl}
+      href={contentUrl}
       onClick={handleMarkAsRead}
       data-testid={`notification-${id}`}
+      rel="noopener noreferrer"
     >
       <Icon
         src={iconComponent}
@@ -62,7 +62,7 @@ const NotificationRowItem = ({
           )}
         </div>
       </div>
-    </Link>
+    </a>
   );
 };
 


### PR DESCRIPTION
[INF-951](https://2u-internal.atlassian.net/browse/INF-951)

#### Description

In frontend-component-header, when clicking on a notification, it was redirectsing to the wrong URL, which is fixed in this PR