### PR TITLE
fix: course name was not visible in notification

### DIFF
--- a/src/Notifications/NotificationSections.jsx
+++ b/src/Notifications/NotificationSections.jsx
@@ -60,7 +60,7 @@ const NotificationSections = () => {
             type={notification.type}
             contentUrl={notification.contentUrl}
             content={notification.content}
-            courseName={notification.courseName}
+            courseName={notification.contentContext?.courseName || ''}
             createdAt={notification.createdAt}
             lastRead={notification.lastRead}
           />


### PR DESCRIPTION
Course name was not visible in notification

Ticket: [INF-940](https://2u-internal.atlassian.net/browse/INF-940)

UI after changes: (These attached image UI is different because theme has not been applied)
![Screenshot from 2023-07-13 15-15-31](https://github.com/openedx/frontend-component-header/assets/77053848/5cd5fc60-1d9f-46cb-8b77-05fa61a256b3)
