### PR TITLE
fix: broken studio home link

### DIFF
--- a/src/studio-header/utils.js
+++ b/src/studio-header/utils.js
@@ -8,7 +8,7 @@ const getUserMenuItems = ({
 }) => {
   let items = [
     {
-      href: `${studioBaseUrl}}`,
+      href: `${studioBaseUrl}`,
       title: intl.formatMessage(messages['header.user.menu.studio']),
     }, {
       href: `${logoutUrl}`,


### PR DESCRIPTION
JIRA Ticket: [TNL-11179](https://2u-internal.atlassian.net/browse/TNL-11179)
> When we try to click on 'Studio Home' under username, we repeatedly encounter the error message stating that 'Studio Home' cannot be reached.

Testing

On each of the Cours Authoring pages, check that the "Studio Home" option in the user menu properly navigates the user back to the home page.