### PR TITLE
fix: update frontend-platform peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "redux-saga": "1.3.0"
       },
       "peerDependencies": {
-        "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
+        "@edx/frontend-platform": "^7.0.0",
         "@openedx/paragon": ">= 21.5.7 < 22.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-transition-group": "4.4.5"
   },
   "peerDependencies": {
-    "@edx/frontend-platform": "^4.0.0 || ^5.0.0 || ^6.0.0",
+    "@edx/frontend-platform": "^7.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
This updates the `frontend-platform` peer dependency to require a version that has paragon in the `openedx` scope as a peer dependency, as opposed to the `edx` scope