### PR TITLE
build: start releasing alpha packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - master
+    - alpha
 jobs:
   release:
     name: Release

--- a/.releaserc
+++ b/.releaserc
@@ -1,5 +1,8 @@
 {
-  "branch": "master",
+  "branches": [
+    "master",
+    {name: "alpha", prerelease: true}
+  ],
   "tagFormat": "v${version}",
   "verifyConditions": [
     "@semantic-release/npm",


### PR DESCRIPTION
### Description

Start publishing `alpha` packages, in order to facilitate testing of breaking changes.

### More info

This was motivated by https://github.com/openedx/frontend-build/pull/415.