### PR TITLE
fix: expose app entrypoint in webpack dev config for example app

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,7 +2,9 @@ const path = require('path');
 const { createConfig } = require('@openedx/frontend-build');
 
 module.exports = createConfig('webpack-dev', {
-  entry: path.resolve(__dirname, 'example'),
+  entry: {
+    app: path.resolve(__dirname, 'example'),
+  },
   output: {
     path: path.resolve(__dirname, 'example/dist'),
     publicPath: '/',


### PR DESCRIPTION
Currently, running `npm start` on a fresh checkout results in a blank example app running on `localhost:8080`. This is a result of the recently merged `ParagonWebpackPlugin` changes in `@openedx/frontend-build` which assumes MFEs define an `app` entrypoint, as is the case in the default `webpack.dev.config` provided by `@openedx/frontend-build`, which this repo's example app overrides to be non-standard.

This PR defines the `app` entrypoint in `webpack.dev.config.js`.