### PR TITLE
Temporarily Re-Introduce Studio Maintenance Header Link

### DIFF
--- a/src/Header.messages.jsx
+++ b/src/Header.messages.jsx
@@ -61,6 +61,11 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to the Studio Home',
   },
+  'header.user.menu.studio.maintenance': {
+    id: 'header.user.menu.studio.maintenance',
+    defaultMessage: 'Maintenance',
+    description: 'Link to the Studio Maintenance',
+  },
   'header.label.account.nav': {
     id: 'header.label.account.nav',
     defaultMessage: 'Account',

--- a/src/studio-header/StudioHeader.test.jsx
+++ b/src/studio-header/StudioHeader.test.jsx
@@ -12,6 +12,7 @@ import { Context as ResponsiveContext } from 'react-responsive';
 import { MemoryRouter } from 'react-router-dom';
 
 import StudioHeader from './StudioHeader';
+import messages from './messages';
 
 const authenticatedUser = {
   userId: 3,
@@ -114,6 +115,16 @@ describe('Header', () => {
       expect(dropdownOption).toBeVisible();
     });
 
+    it('maintenance should not be in user menu', async () => {
+      currentUser = { ...authenticatedUser, administrator: false };
+      const { getAllByRole, queryByText } = render(<RootWrapper {...props} />);
+      const userMenu = getAllByRole('button')[1];
+      await waitFor(() => fireEvent.click(userMenu));
+      const maintenanceButton = queryByText(messages['header.user.menu.maintenance'].defaultMessage);
+
+      expect(maintenanceButton).toBeNull();
+    });
+
     it('user menu should use avatar icon', async () => {
       currentUser = { ...authenticatedUser, avatar: null };
       const { getByTestId } = render(<RootWrapper {...props} />);
@@ -173,6 +184,15 @@ describe('Header', () => {
       const desktopMenu = queryByTestId('desktop-menu');
 
       expect(desktopMenu).toBeNull();
+    });
+
+    it('maintenance should be in user menu', async () => {
+      const { getAllByRole, getByText } = render(<RootWrapper {...props} />);
+      const userMenu = getAllByRole('button')[1];
+      await waitFor(() => fireEvent.click(userMenu));
+      const maintenanceButton = getByText(messages['header.user.menu.maintenance'].defaultMessage);
+
+      expect(maintenanceButton).toBeVisible();
     });
 
     it('user menu should use avatar image', async () => {

--- a/src/studio-header/messages.js
+++ b/src/studio-header/messages.js
@@ -6,6 +6,11 @@ const messages = defineMessages({
     defaultMessage: 'Studio Home',
     description: 'Link to Studio Home',
   },
+  'header.user.menu.maintenance': {
+    id: 'header.user.menu.maintenance',
+    defaultMessage: 'Maintenance',
+    description: 'Link to the Studio maintenance page',
+  },
   'header.user.menu.logout': {
     id: 'header.user.menu.logout',
     defaultMessage: 'Logout',

--- a/src/studio-header/utils.js
+++ b/src/studio-header/utils.js
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import messages from './messages';
 
 const getUserMenuItems = ({
@@ -20,6 +21,9 @@ const getUserMenuItems = ({
       {
         href: `${studioBaseUrl}`,
         title: intl.formatMessage(messages['header.user.menu.studio']),
+      }, {
+        href: `${getConfig().STUDIO_BASE_URL}/maintenance`,
+        title: intl.formatMessage(messages['header.user.menu.maintenance']),
       }, {
         href: `${logoutUrl}`,
         title: intl.formatMessage(messages['header.user.menu.logout']),


### PR DESCRIPTION
Reverts openedx/frontend-component-header#553

We are temporarily re-introducing the Maintenance link, as the Maintenance Announcements tool is still in use, as discussed on: https://github.com/openedx/edx-platform/pull/35852

This PR depends on this related revert PR: https://github.com/openedx/edx-platform/pull/36107
