### PR TITLE
feat!: remove Paragon 21 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
       },
       "peerDependencies": {
         "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-        "@openedx/paragon": ">= 21.5.7 < 23.0.0",
+        "@openedx/paragon": "^22.0.0",
         "prop-types": "^15.5.10",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "@edx/frontend-platform": "^7.0.0 || ^8.0.0",
-    "@openedx/paragon": ">= 21.5.7 < 23.0.0",
+    "@openedx/paragon": "^22.0.0",
     "prop-types": "^15.5.10",
     "react": "^16.9.0 || ^17.0.0",
     "react-dom": "^16.9.0 || ^17.0.0",


### PR DESCRIPTION
BREAKING CHANGE: consumers must now use Paragon 22

To understand the impact of this change, I've looked for all repos in the org with `frontend-component-header` in their `package.json` files ([search](https://github.com/search?q=org%3Aopenedx+frontend-component-header+language%3Ajson&type=code)).

> [!NOTE]
> There are enterprise repos that appear in this search that include `frontend-component-header-edx` - [that is a different repo](https://github.com/edx/frontend-component-header-edx).

| Repo | Ready | Reason |
| - | - | - |
| [`frontend-template-application`](https://github.com/openedx/frontend-template-application/blob/5559e269c174579a40b5445ef761d2ae6dc0f975/package.json#L38) | :heavy_check_mark: | No `paragon` dependency |
| [`frontend-app-learning`](https://github.com/openedx/frontend-app-learning/blob/964abbe0c3d64350b0e47fb29a570543f8458e57/package.json#L38) | :heavy_check_mark: | [`"@openedx/paragon": "^22.3.0"`](https://github.com/openedx/frontend-app-learning/blob/964abbe0c3d64350b0e47fb29a570543f8458e57/package.json#L51) |
| [`frontend-app-discussions`](https://github.com/openedx/frontend-app-discussions/blob/58aa512f47957063f300095c516cbf4b031c7d6d/package.json#L37) | :heavy_check_mark: | [`"@openedx/paragon": "^22.1.1"`](https://github.com/openedx/frontend-app-discussions/blob/58aa512f47957063f300095c516cbf4b031c7d6d/package.json#L41) |
| [`frontend-app-authoring`](https://github.com/openedx/frontend-app-authoring/blob/a26e3f9e92f4d778311e4c51267e84d304a7611d/package.json#L53) | :heavy_check_mark: | [`"@openedx/paragon": "^22.8.1"`](https://github.com/openedx/frontend-app-authoring/blob/a26e3f9e92f4d778311e4c51267e84d304a7611d/package.json#L69) |
| [`frontend-app-learner-dashboard`](https://github.com/openedx/frontend-app-learner-dashboard/blob/10961010ba16dc0d3acfaa0e738d64e936b9f8e5/package.json#L34) | :heavy_check_mark: | [`"@openedx/paragon": "^22.2.2"`](https://github.com/openedx/frontend-app-learner-dashboard/blob/10961010ba16dc0d3acfaa0e738d64e936b9f8e5/package.json#L45) |
| [`frontend-app-profile`](https://github.com/openedx/frontend-app-profile/blob/2ef5a7baff51124d975971520e6c4433097312a7/package.json#L32) | :heavy_check_mark: | [`"@openedx/paragon": "^22.2.2"`](https://github.com/openedx/frontend-app-profile/blob/2ef5a7baff51124d975971520e6c4433097312a7/package.json#L41) |
| [`frontend-app-account`](https://github.com/openedx/frontend-app-account/blob/99a39568defe69a66fa3783c038cdd15ed844bb1/package.json#L32) | :heavy_check_mark: | [`"@openedx/paragon": "22.13.0"`](https://github.com/openedx/frontend-app-account/blob/99a39568defe69a66fa3783c038cdd15ed844bb1/package.json#L42) |
| [`frontend-app-gradebook`](https://github.com/openedx/frontend-app-gradebook/blob/49da0175e8702e2c96d01d4e497b7c414bda0bba/package.json#L32) | :heavy_check_mark: | [`"@openedx/paragon": "^22.1.1"`](https://github.com/openedx/frontend-app-gradebook/blob/49da0175e8702e2c96d01d4e497b7c414bda0bba/package.json#L43) |
| [`frontend-app-learner-record`](https://github.com/openedx/frontend-app-learner-record/blob/97afcb7017036a037833f35983406ead3e6b19b1/package.json#L39) | :heavy_check_mark: | [`"@openedx/paragon": "^22.2.2"`](https://github.com/openedx/frontend-app-learner-record/blob/97afcb7017036a037833f35983406ead3e6b19b1/package.json#L48) |
| [`frontend-app-ora-grading`](https://github.com/openedx/frontend-app-ora-grading/blob/7aee8562a8a5c6307c355d7e4e752595cd132751/package.json#L31) | :x: | [`"@openedx/paragon": "21.11.3"`](https://github.com/openedx/frontend-app-ora-grading/blob/7aee8562a8a5c6307c355d7e4e752595cd132751/package.json#L39) |
| [`frontend-app-communications`](https://github.com/openedx/frontend-app-communications/blob/445a2f6cd34adbb343468eeca8d07f99f95c2570/package.json#L37) | :heavy_check_mark: | [`"@openedx/paragon": "^22.0.0"`](https://github.com/openedx/frontend-app-communications/blob/445a2f6cd34adbb343468eeca8d07f99f95c2570/package.json#L48) |

> [!WARNING]  
> The only repo that will require attention after this lands is `frontend-app-ora-grading`. I see 2 possible paths forward for this:
> 1. Make a PR updating `frontend-app-ora-grading` from Paragon 21 to Paragon 22.
> 2. Let `frontend-app-ora-grading` stay on Paragon 21 until we are ready to land the update to design tokens/Paragon 23 on all MFEs
>
> I have no strong feelings one way or the other, and I'd be happy to PR a 21 -> 22 upgrade to `frontend-app-ora-grading` if people feel that is preferable.