### PR TITLE
chore: remove husky 🪓🐶

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "5.17.0",
         "@testing-library/react": "^16.2.0",
-        "husky": "8.0.3",
         "jest": "29.7.0",
         "jest-chain": "1.1.6",
         "prop-types": "15.8.1",
@@ -11393,22 +11392,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyperdyperid": {

--- a/package.json
+++ b/package.json
@@ -17,11 +17,6 @@
   "files": [
     "/dist"
   ],
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run lint"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openedx/frontend-component-header.git"
@@ -42,7 +37,6 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "5.17.0",
     "@testing-library/react": "^16.2.0",
-    "husky": "8.0.3",
     "jest": "29.7.0",
     "jest-chain": "1.1.6",
     "prop-types": "15.8.1",


### PR DESCRIPTION
We remove husky, which is triggering pre-push git hooks, including running "npm lint". This is causing failures when building Docker images, because "npm clean-install --omit=dev" automatically triggers "npm prepare", which attemps to run "husky". But husky is not listed in the build dependencies, only in devDependencies. As a consequence, package installation is failing with the following error:

        14.13 > @edx/frontend-app-ora-grading@0.0.1 prepare
        14.13 > husky install
        14.13
        14.15 sh: 1: husky: not found

Similar to: https://github.com/openedx/frontend-app-learning/pull/1622