### PR TITLE
feat: Props passed down to plugins.

### DIFF
--- a/src/plugin-slots/CourseInfoSlot/index.jsx
+++ b/src/plugin-slots/CourseInfoSlot/index.jsx
@@ -18,6 +18,7 @@ const CourseInfoSlot = ({
       courseOrg,
       courseNumber,
       courseTitle,
+      attributes,
     }}
   >
     <LearningHeaderCourseInfo

--- a/src/plugin-slots/DesktopHeaderSlot/index.jsx
+++ b/src/plugin-slots/DesktopHeaderSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopHeaderSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={props}
   >
     <DesktopHeader {...props} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/DesktopLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginPrope={{ items }}
   >
     <DesktopLoggedOutItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopMainMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopMainMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopMainMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderMainOrSecondaryMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopSecondaryMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopSecondaryMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopSecondaryMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderMainOrSecondaryMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/DesktopUserMenuSlot/index.jsx
+++ b/src/plugin-slots/DesktopUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const DesktopUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <DesktopHeaderUserMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/LearningLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/LearningLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const LearningLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ buttonsInfo }}
   >
     <LearningLoggedOutButtons buttonsInfo={buttonsInfo} />
   </PluginSlot>

--- a/src/plugin-slots/LearningUserMenuSlot/index.jsx
+++ b/src/plugin-slots/LearningUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const LearningUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ items }}
   >
     <LearningHeaderUserMenuItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/LogoSlot/index.jsx
+++ b/src/plugin-slots/LogoSlot/index.jsx
@@ -11,6 +11,9 @@ const LogoSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    props={{
+      href, src, alt, attributes,
+    }}
   >
     <Logo href={href} src={src} alt={alt} {...attributes} />
   </PluginSlot>

--- a/src/plugin-slots/MobileHeaderSlot/index.jsx
+++ b/src/plugin-slots/MobileHeaderSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileHeaderSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={props}
   >
     <MobileHeader {...props} />
   </PluginSlot>

--- a/src/plugin-slots/MobileLoggedOutItemsSlot/index.jsx
+++ b/src/plugin-slots/MobileLoggedOutItemsSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileLoggedOutItemsSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ items }}
   >
     <MobileLoggedOutItems items={items} />
   </PluginSlot>

--- a/src/plugin-slots/MobileMainMenuSlot/index.jsx
+++ b/src/plugin-slots/MobileMainMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileMainMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <MobileHeaderMainMenu menu={menu} />
   </PluginSlot>

--- a/src/plugin-slots/MobileUserMenuSlot/index.jsx
+++ b/src/plugin-slots/MobileUserMenuSlot/index.jsx
@@ -11,6 +11,7 @@ const MobileUserMenuSlot = ({
     slotOptions={{
       mergeProps: true,
     }}
+    pluginProps={{ menu }}
   >
     <MobileHeaderUserMenu menu={menu} />
   </PluginSlot>


### PR DESCRIPTION
This PR adds pluginProps to the various slots available in the MFE. At present, it is impossible to access the same props passed to upstream components, requiring any replacement components to become second class citizens in their construction. For instance, a replacement menu component will not receive the menu items. This requires either foregoing making a replacement menu entirely, or coming up with a completely parallel method of constructing the menus.

**Testing instructions**:

TBD

**Author notes and concerns**:

1. Some of the slots just pass a plain 'props' object, which I've passed along unaltered. It isn't clear by looking at the plugin code what these props are.
2. The 'attributes' prop some slots have is also passed along but may be arguable for inclusion.
3. This could affect any existing plugins that may be leveraging these slots. However, that effect should be negligible since they did not previously have access to these props.