### PR TITLE
fix: size and crop Studio profile avatars

### DIFF
--- a/src/studio-header/StudioHeader.test.tsx
+++ b/src/studio-header/StudioHeader.test.tsx
@@ -18,7 +18,6 @@ const authenticatedUser = {
   username: 'abc123',
   administrator: true,
   roles: [],
-  avatar: '/imges/test.png',
 };
 let currentUser;
 let screenWidth = 1280;
@@ -115,7 +114,6 @@ describe('Header', () => {
     });
 
     it('user menu should use avatar icon', async () => {
-      currentUser = { ...authenticatedUser, avatar: null };
       const { getByTestId } = render(<RootWrapper {...props} />);
       const avatarIcon = getByTestId('avatar-icon');
 
@@ -127,7 +125,6 @@ describe('Header', () => {
     it('user menu should use avatar icon when hydrated profile image has no image', async () => {
       currentUser = {
         ...authenticatedUser,
-        avatar: null,
         profileImage: {
           hasImage: false,
           imageUrlMedium: '/profile-images/abc123-medium.png',
@@ -140,10 +137,9 @@ describe('Header', () => {
       expect(queryByTestId('avatar-image')).not.toBeInTheDocument();
     });
 
-    it('user menu should use hydrated profile image when avatar is not present', async () => {
+    it('user menu should use hydrated profile image when available', async () => {
       currentUser = {
         ...authenticatedUser,
-        avatar: null,
         profileImage: {
           hasImage: true,
           imageUrlMedium: '/profile-images/abc123-medium.png',
@@ -156,21 +152,6 @@ describe('Header', () => {
       expect(avatarImage).toHaveAttribute('src', '/profile-images/abc123-medium.png');
       expect(avatarImage).toHaveAttribute('alt', authenticatedUser.username);
       expect(avatarImage).toHaveClass('pgn__avatar-sm', 'mr-2');
-    });
-
-    it('user menu should prefer avatar over hydrated profile image', async () => {
-      currentUser = {
-        ...authenticatedUser,
-        profileImage: {
-          hasImage: true,
-          imageUrlMedium: '/profile-images/abc123-medium.png',
-        },
-      };
-      const { getByTestId } = render(<RootWrapper {...props} />);
-      const avatarImage = getByTestId('avatar-image');
-
-      expect(avatarImage).toBeVisible();
-      expect(avatarImage).toHaveAttribute('src', authenticatedUser.avatar);
     });
 
     it('should hide nav items if prop isHiddenMainMenu true', async () => {
@@ -226,11 +207,19 @@ describe('Header', () => {
       expect(desktopMenu).toBeNull();
     });
 
-    it('user menu should use avatar image', async () => {
+    it('user menu should use hydrated profile image', async () => {
+      currentUser = {
+        ...authenticatedUser,
+        profileImage: {
+          hasImage: true,
+          imageUrlMedium: '/profile-images/abc123-medium.png',
+        },
+      };
       const { getByTestId } = render(<RootWrapper {...props} />);
       const avatarImage = getByTestId('avatar-image');
 
       expect(avatarImage).toBeVisible();
+      expect(avatarImage).toHaveAttribute('src', '/profile-images/abc123-medium.png');
     });
 
     it('should hide nav items if prop isHiddenMainMenu true', async () => {

--- a/src/studio-header/StudioHeader.test.tsx
+++ b/src/studio-header/StudioHeader.test.tsx
@@ -120,6 +120,8 @@ describe('Header', () => {
       const avatarIcon = getByTestId('avatar-icon');
 
       expect(avatarIcon).toBeVisible();
+      expect(avatarIcon).toHaveAttribute('alt', authenticatedUser.username);
+      expect(avatarIcon).toHaveClass('pgn__avatar-sm', 'mr-2');
     });
 
     it('user menu should use avatar icon when hydrated profile image has no image', async () => {
@@ -152,6 +154,8 @@ describe('Header', () => {
 
       expect(avatarImage).toBeVisible();
       expect(avatarImage).toHaveAttribute('src', '/profile-images/abc123-medium.png');
+      expect(avatarImage).toHaveAttribute('alt', authenticatedUser.username);
+      expect(avatarImage).toHaveClass('pgn__avatar-sm', 'mr-2');
     });
 
     it('user menu should prefer avatar over hydrated profile image', async () => {

--- a/src/studio-header/StudioHeader.tsx
+++ b/src/studio-header/StudioHeader.tsx
@@ -41,8 +41,7 @@ const StudioHeader: FunctionComponent<Props> = ({
   // @ts-expect-error - frontend-platform doesn't yet have type information :/
   const { authenticatedUser, config } = useContext(AppContext);
   const profileImage = authenticatedUser?.profileImage;
-  const authenticatedUserAvatar = authenticatedUser?.avatar
-    || (profileImage?.hasImage ? profileImage.imageUrlMedium : null);
+  const authenticatedUserAvatar = profileImage?.hasImage ? profileImage.imageUrlMedium : null;
   const props = {
     logo: config.LOGO_URL,
     logoAltText: `Studio ${config.SITE_NAME}`,

--- a/src/studio-header/UserMenu.tsx
+++ b/src/studio-header/UserMenu.tsx
@@ -16,19 +16,13 @@ const UserMenu = ({
   isAdmin,
 }) => {
   const intl = useIntl();
-  const avatar = authenticatedUserAvatar ? (
-    <img
-      className="d-block w-100 h-100"
-      src={authenticatedUserAvatar}
-      alt={username}
-      data-testid="avatar-image"
-    />
-  ) : (
+  const avatar = (
     <Avatar
+      src={authenticatedUserAvatar}
       size="sm"
       className="mr-2"
       alt={username}
-      data-testid="avatar-icon"
+      data-testid={authenticatedUserAvatar ? 'avatar-image' : 'avatar-icon'}
     />
   );
   const title = isMobile ? avatar : <>{avatar}{username}</>;


### PR DESCRIPTION
## Description
This PR fixes the bug @bradenmacdonald raised in reviewing the avatar fix https://github.com/openedx/frontend-app-authoring/pull/3043

This updates the previously merged #670 fix to properly render circular images, and removes the unused `.avatar`... I incorrectly assumed it was some legacy contract, but given the discovery in #673 , I just removed it. 

### Prior to #670: No avatar images ever loaded
`StudioHeader` passed only `authenticatedUser.avatar` to the Studio user menu.
`UserMenu` already had two rendering paths:
- When an avatar URL was present, it rendered a raw `<img>` with `d-block w-100 h-100`.
- When no URL was present, it rendered Paragon’s `Avatar` with `size="sm"` and `mr-2`.
- used the unsupported `authenticatedUser.avatar`

Studio did not read the uploaded profile image exposed through the hydrated `authenticatedUser.profileImage` data, so uploaded Open edX profile images did not reach the raw-image path.

### #670: Added Avatar images when available

#670 updated `StudioHeader` to use the hydrated profile image when available:
- Continue preferring `authenticatedUser.avatar`.
- Otherwise use `profileImage.imageUrlMedium` when `profileImage.hasImage` is true.
- Otherwise preserve the existing fallback avatar.

The companion Authoring change, openedx/frontend-app-authoring#3043, enables authenticated-user hydration so Studio can receive that profile-image data.

#670 intentionally changed only avatar URL selection. It did not change how `UserMenu` presents an avatar after receiving a URL.

When tested, the image rendered as expected, but `w-100 h-100` made the menu button layout to determine the image dimensions causing the issue Braden found.

### This PR

This PR replaces the separate raw-image and fallback branches with the existing Paragon `Avatar` component for both states. The selected profile-image URL is passed through `src`, allowing Paragon to provide:
- The existing small fixed avatar size.
- Circular clipping.
- Cover behavior for non-square images.
- Consistent spacing and alignment.

This PR also removes the unsupported `authenticatedUser.avatar` and now selects `profileImage.imageUrlMedium` when `profileImage.hasImage` is true. The change preserves the accessible name, `mr-2` spacing, and `avatar-image` / `avatar-icon` test hooks.

This is the sizing and cropping follow-up reported in #673, with cleanup to remove `authenticatedUser.avatar`

## Tests Done

- `npm test -- --runTestsByPath src/studio-header/StudioHeader.test.tsx --runInBand` — 1 suite and 15 tests passed.
- `npm run types` — passed.
- `git diff --check` — passed.
- Manually checked uploaded and fallback avatars in the local component harness at desktop and mobile widths.
- Manually checked an uploaded profile image in Tutor-dev Authoring with authenticated-user hydration enabled; the image loaded correctly and rendered as a circular Studio avatar.

## AI Assistance

AI tools were used to aid in diagnosis, planning, implementation, and review. All work was manually verified.